### PR TITLE
Update to support Action passed in as either Publish or Script

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/DeployToSqlServer.ps1
@@ -59,7 +59,9 @@ function GetScriptToRun
         [string]$sqlPassword,
         [string]$connectionString,
         [string]$publishProfile,
-        [string]$additionalArguments
+        [string]$additionalArguments,
+        [string]$action,
+	    [string]$outputPath
     )
 
     $sqlPackageScript = Get-Content .\SqlPackageOnTargetMachines.ps1 | Out-String
@@ -68,7 +70,7 @@ function GetScriptToRun
     $sqlPassword = EscapeSpecialChars -str $sqlPassword
     $additionalArguments = EscapeSpecialChars -str $additionalArguments
 
-    $invokeMain = "ExecuteMain -dacpacFile `"$dacpacFile`" -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUsername `"$sqlUsername`" -sqlPassword `"$sqlPassword`" -connectionString `"$connectionString`" -publishProfile `"$publishProfile`" -additionalArguments `"$additionalArguments`""
+    $invokeMain = "ExecuteMain -dacpacFile `"$dacpacFile`" -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUsername `"$sqlUsername`" -sqlPassword `"$sqlPassword`" -connectionString `"$connectionString`" -publishProfile `"$publishProfile`" -additionalArguments `"$additionalArguments`" -action `"$action`" -outputPath `"$outputPath`""
 
     Write-Verbose "Executing main funnction in SqlPackageOnTargetMachines : $invokeMain"
     $sqlDacpacOnTargetMachinesScript = [string]::Format("{0} {1} ( {2} )", $sqlPackageScript,  [Environment]::NewLine,  $invokeMain)
@@ -93,7 +95,9 @@ function Main
     [string]$connectionString,
     [string]$publishProfile,
     [string]$additionalArguments,
-    [string]$deployInParallel
+    [string]$deployInParallel,
+    [string]$action,
+	[string]$outputPath
     )
 
     Write-Verbose "Entering script DeployToSqlServer.ps1"
@@ -110,9 +114,11 @@ function Main
     Write-Verbose "publishProfile = $publishProfile"
     Write-Verbose "additionalArguments = $additionalArguments"
     Write-Verbose "deployInParallel = $deployInParallel"
+    Write-Verbose "action = $action"
+    Write-Verbose "outputPath = $outputPath"
 
     TrimInputs -adminUserName([ref]$adminUserName) -sqlUsername ([ref]$sqlUsername) -dacpacFile ([ref]$dacpacFile) -publishProfile ([ref]$publishProfile)
 
-    $script = GetScriptToRun -dacpacFile $dacpacFile -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUserName $sqlUsername -sqlPassword $sqlPassword -connectionString $connectionString -publishProfile $publishProfile -additionalArguments $additionalArguments
+    $script = GetScriptToRun -dacpacFile $dacpacFile -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUserName $sqlUsername -sqlPassword $sqlPassword -connectionString $connectionString -publishProfile $publishProfile -additionalArguments $additionalArguments -action $action -outputPath $outputPath
     RunRemoteDeployment -machinesList $machinesList -scriptToRun $script -adminUserName $adminUserName -adminPassword $adminPassword -winrmProtocol $winrmProtocol -testCertificate $testCertificate -deployInParallel $deployInParallel -dacpacFile $dacpacFile
 }

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/Main.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/Main.ps1
@@ -14,11 +14,13 @@ param (
     [string]$connectionString,
     [string]$publishProfile,
     [string]$additionalArguments,
-    [string]$deployInParallel
+    [string]$deployInParallel,
+    [string]$action,
+	[string]$outputPath
     )
 
 $env:CURRENT_TASK_ROOTDIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 . $env:CURRENT_TASK_ROOTDIR\DeployToSqlServer.ps1
 
-(Main -machinesList $machinesList -adminUserName $adminUserName -adminPassword $adminPassword -winrmProtocol $winrmProtocol -testCertificate $testCertificate -dacpacFile $dacpacFile -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUsername $sqlUsername -sqlPassword $sqlPassword -connectionString $connectionString -publishProfile $publishProfile -additionalArguments $additionalArguments -deployInParallel $deployInParallel)
+(Main -machinesList $machinesList -adminUserName $adminUserName -adminPassword $adminPassword -winrmProtocol $winrmProtocol -testCertificate $testCertificate -dacpacFile $dacpacFile -targetMethod $targetMethod -serverName $serverName -databaseName $databaseName -authscheme $authscheme -sqlUsername $sqlUsername -sqlPassword $sqlPassword -connectionString $connectionString -publishProfile $publishProfile -additionalArguments $additionalArguments -deployInParallel $deployInParallel -action $action -outputPath $outputPath)

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/task.json
@@ -178,6 +178,29 @@
       "helpMarkDown": "Publish profile provide fine-grained control over SQL Server database deployments. Specify the path to the Publish profile XML file on the target machine or on a UNC share that is accessible by the machine administrator's credentials."
     },
     {
+			"name": "Action",
+			"type": "pickList",
+			"label": "Specify Action",
+			"required": true,
+			"groupName": "target",
+			"defaultValue": "publish",
+			"options": {
+				"publish": "Publish",
+				"script": "Script"
+			},
+			"helpMarkDown": "Choose if the task will publish the dacpac (change the database) or script the changes. If Script is choosen, Output Path is required"
+		},
+		{
+			"name": "OutputPath",
+			"type": "string",
+			"label": "Output File",
+			"required": true,
+			"groupName": "target",
+			"defaultValue": "",
+			"visibleRule": "Action = script",
+			"helpMarkDown": "Path on the remote server to save the sql script created by the dacpac"
+		},
+    {
       "name": "AdditionalArguments",
       "type": "multiLine",
       "label": "Additional Arguments",


### PR DESCRIPTION
Allow the user to pick if they want to publish (current only behavior)
or script.. if they choose to script they can then enter a path to store
the script.. This is useful when DBAs would like to know what "happened"
or if during a deployment to a lower environment (QA, UAT, Integration)
they would like to output the script for review prior to running the
production deployment.