### PR TITLE
authscheme value properly managed

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlPackageOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlPackageOnTargetMachines.ps1
@@ -376,7 +376,7 @@ function Get-SqlPackageCmdArgs
             $sqlPkgCmdArgs = [string]::Format('{0} /TargetDatabaseName:"{1}"', $sqlPkgCmdArgs, $databaseName)
         }
 
-        if($authscheme -eq "SQL Server Authentication")
+        if($authscheme -eq "sqlServerAuthentication")
         {
             $sqlPkgCmdArgs = [string]::Format('{0} /TargetUser:"{1}" /TargetPassword:"{2}"', $sqlPkgCmdArgs, $sqlUsername, $sqlPassword)
         }


### PR DESCRIPTION
The user and password must be passed when SQL Server Authentication is selected (that is when the authscheme picklist value is "sqlServerAuthentication" ). The original code compared to the label "SQL Server Authentication", not to the actual picklist value.