### PR TITLE
Update AppCmdOnTargetMachines.ps1

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/AppCmdOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/AppCmdOnTargetMachines.ps1
@@ -100,7 +100,7 @@ function Does-BindingExists
     Write-Verbose "Checking binding exists for website (`"$siteName`"). Running command : $command"
 
     $sites = Run-Command -command $command -failOnErr $false
-    $binding = [string]::Format("{0}/{1}:{2}:{3}", $protocol, $ipAddress, $port, $hostname)
+    $binding = [string]::Format("{0}/{1}:{2}:{3},", $protocol, $ipAddress, $port, $hostname)
 
     $isBindingExists = $false
 


### PR DESCRIPTION
Bug: Given binding already exists for a different website.
function Does-BindingExists: added comma to the end of the binding string which falsely identified a used binding from another site that started with the same string.