### PR TITLE
added IPAddress as parm and fixed addCertCmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Extensions/BitBucket/DownloadArtifactBitbucket/obj/*
 
 ## Nuget 
 nuget.exe
+Extensions/**/DeploymentSDK

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/AppCmdOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/AppCmdOnTargetMachines.ps1
@@ -182,7 +182,8 @@ function Add-SslCert
         [string]$certhash,
         [string]$hostname,
         [string]$sni,
-        [string]$iisVersion
+        [string]$iisVersion,
+        [string]$ipAddress
     )
 
     if([string]::IsNullOrWhiteSpace($certhash))
@@ -208,13 +209,13 @@ function Add-SslCert
     }
     else
     {
-        $showCertCmd = [string]::Format("netsh http show sslcert ipport=0.0.0.0:{0}", $port)
+        $showCertCmd = [string]::Format("netsh http show sslcert ipport={0}:{1}", $ipAddress, $port)
         Write-Verbose "Checking if SslCert binding is already present. Running command : $showCertCmd"
 
         $result = Run-Command -command $showCertCmd -failOnErr $false
-        $isItSameBinding = $result.Get(4).Contains([string]::Format("0.0.0.0:{0}", $port))
+        $isItSameBinding = $result.Get(4).Contains([string]::Format("{0}:{1}", $ipAddress, $port))
         
-        $addCertCmd = [string]::Format("netsh http add sslcert ipport=0.0.0.0:{0} certhash={1} appid={{{2}}}", $port, $certhash, [System.Guid]::NewGuid().toString())
+        $addCertCmd = [string]::Format("netsh http add sslcert ipport={0}:{1} certhash={2} appid={{{3}}} certstorename=MY", $ipAddress, $port, $certhash, [System.Guid]::NewGuid().toString())
     }
 
     $isItSameCert = $result.Get(5).ToLower().Contains($certhash.ToLower())
@@ -505,7 +506,7 @@ function Execute-Main
         if($Protocol -ieq "https" -and $AddBinding -ieq "true")
         {
             $appCmdPath, $iisVersion = Get-AppCmdLocation -regKeyPath $AppCmdRegKey
-            Add-SslCert -port $Port -certhash $SslCertThumbPrint -hostname $HostName -sni $ServerNameIndication -iisVersion $iisVersion
+            Add-SslCert -ipAddress $IpAddress -port $Port -certhash $SslCertThumbPrint -hostname $HostName -sni $ServerNameIndication -iisVersion $iisVersion
             Enable-SNI -siteName $WebsiteName -sni $ServerNameIndication -ipAddress $IpAddress -port $Port -hostname $HostName
         }
     }


### PR DESCRIPTION
added ability to pass IPAddress parm to the Add-SslCert function
Also, in spite of the expected behavior for "netsh http add sslcert", omitting the certstorename parameter results in the issue as raised in issue #140