### PR TITLE
Show builds from all branches and not only from default branch

### DIFF
--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -78,7 +78,7 @@
           },
           {
             "name": "LatestBuild",
-            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds?count=1&status=success",
+            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds?locator=branch:default:any&count=1&status=success",
             "resultSelector": "jsonpath:$.build[*]"
           },
           {

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -73,7 +73,7 @@
           },
           {
             "name": "Builds",
-            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds",
+            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds/?locator=branch:default:any",
             "resultSelector": "jsonpath:$.build[?(@.status=='SUCCESS')]"
           },
           {


### PR DESCRIPTION
Currently the TeamCity extension only allows to deploy artifacts from the default branch. This change will show builds from all branches.

Fixes #220