### PR TITLE
Fix couple of bugs in logger

### DIFF
--- a/ServerTaskHelper/AzureFunctionHandler/MyTaskExecutionHandler.cs
+++ b/ServerTaskHelper/AzureFunctionHandler/MyTaskExecutionHandler.cs
@@ -18,7 +18,7 @@ namespace AzureFunctionHandler
             var myObject = JsonConvert.DeserializeObject<MyTaskObject>(taskMessage.GetTaskMessageBody());
 
             var message = $"Hello {myObject.Name}";
-            taskLogger.Log(message);
+            await taskLogger.Log(message).ConfigureAwait(false);
 
             return await Task.FromResult(TaskResult.Succeeded);
         }

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ExecutionHandler.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ExecutionHandler.cs
@@ -39,7 +39,7 @@ namespace DistributedTask.ServerTask.Remote.Common
                     taskLogger = new TaskLogger(taskProperties, taskClient);
 
                     // report task started
-                    taskLogger.Log("Task started");
+                    await taskLogger.Log("Task started").ConfigureAwait(false);
                     await taskClient.ReportTaskStarted(taskProperties.TaskInstanceId, cancellationToken).ConfigureAwait(false);
                     // start client handler execute
                     var executeTask = taskExecutionHandler.ExecuteAsync(taskMessage, taskLogger, cancellationToken).ConfigureAwait(false);
@@ -47,14 +47,18 @@ namespace DistributedTask.ServerTask.Remote.Common
                     taskResult = await executeTask;
 
                     // report task completed with status
-                    taskLogger.Log("Task completed");
+                    await taskLogger.Log("Task completed").ConfigureAwait(false);
                     await taskClient.ReportTaskCompleted(taskProperties.TaskInstanceId, taskResult, cancellationToken).ConfigureAwait(false);
                     await taskLogger.End().ConfigureAwait(false);
                     return taskResult;
                 }
                 catch (Exception e)
                 {
-                    taskLogger?.Log(e.ToString());
+                    if (taskLogger != null)
+                    {
+                        await taskLogger.Log(e.ToString()).ConfigureAwait(false);
+                    }
+
                     await taskClient.ReportTaskCompleted(taskProperties.TaskInstanceId, taskResult, cancellationToken).ConfigureAwait(false);
                     throw;
                 }
@@ -63,7 +67,7 @@ namespace DistributedTask.ServerTask.Remote.Common
 
         public async Task Cancel(CancellationToken cancellationToken)
         {
-            taskLogger.Log("Canceling task ...");
+            await taskLogger.Log("Canceling task ...").ConfigureAwait(false);
             using (var taskClient = new TaskClient(taskProperties))
             {
                 taskLogger = new TaskLogger(taskProperties, taskClient);

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskLogger.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskLogger.cs
@@ -33,7 +33,7 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
             Directory.CreateDirectory(pagesFolder);
         }
 
-        public async void Log(string message)
+        public async Task Log(string message)
         {
             if (!string.IsNullOrEmpty(message) && message.Length > 1024)
             {
@@ -65,9 +65,8 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
                 await NewPage().ConfigureAwait(false);
             }
 
-            var line = $"{DateTime.UtcNow:O} {message}";
-            pageWriter.WriteLine(line);
-            byteCount += System.Text.Encoding.UTF8.GetByteCount(line);
+            pageWriter.WriteLine(message);
+            byteCount += System.Text.Encoding.UTF8.GetByteCount(message);
             if (byteCount >= PageSize)
             {
                 await NewPage().ConfigureAwait(false);

--- a/ServerTaskHelper/HttpRequestHandler/MyTaskExecutionHandler.cs
+++ b/ServerTaskHelper/HttpRequestHandler/MyTaskExecutionHandler.cs
@@ -18,7 +18,7 @@ namespace HttpRequestHandler
             var myObject = JsonConvert.DeserializeObject<MyTaskObject>(taskMessage.GetTaskMessageBody());
 
             var message = $"Hello {myObject.Name}";
-            taskLogger.Log(message);
+            await taskLogger.Log(message).ConfigureAwait(false);
 
             return await Task.FromResult(TaskResult.Succeeded);
         }

--- a/ServerTaskHelper/ServiceBusMessageHandler/MyTaskExecutionHandler.cs
+++ b/ServerTaskHelper/ServiceBusMessageHandler/MyTaskExecutionHandler.cs
@@ -18,7 +18,7 @@ namespace ServiceBusMessageHandler
             var myObject = JsonConvert.DeserializeObject<MyTaskObject>(taskMessage.GetTaskMessageBody());
 
             var message = $"Hello {myObject.Name}";
-            taskLogger.Log(message);
+            await taskLogger.Log(message).ConfigureAwait(false);
 
             return await Task.FromResult(TaskResult.Succeeded);
         }


### PR DESCRIPTION
Change TaskLogger.Log signature to return Task, so that, can await on the call
Fix to not add datetime twice in logs

